### PR TITLE
Update to support OpenShift v4 Migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,15 @@ These are templates used to deploy baserow to the BC Government's OpenShift clus
 
 ### Installation
 
-#### Recommended
+#### Network Security Policies
 
-oc -n 245e18-dev process -f https://raw.githubusercontent.com/BCDevOps/platform-services/master/security/aporeto/docs/sample/quickstart-nsp.yaml NAMESPACE=245e18-dev | oc -n 245e18-dev create -f -
+Ensure the NSP has been created in each of `-dev`, `-test`, `-prod`,. For example:
+
+```bash
+oc -n <namespace> process -f https://raw.githubusercontent.com/BCDevOps/platform-services/master/security/aporeto/docs/sample/quickstart-nsp.yaml NAMESPACE=245e18-dev | oc -n <namespace> create -f -
+```
+
+#### Recommended
 
 Process and apply build templates.
 
@@ -23,8 +29,8 @@ oc -n <namespace> process -f web-frontend.build.yml | oc apply -f -
 Process and apply deploy templates.
 
 ```bash
-oc -n <namespace> process -f backend.deploy.yml | oc apply -f -
 oc -n <namespace> process -f database.deploy.yml | oc apply -f -
+oc -n <namespace> process -f backend.deploy.yml | oc apply -f -
 oc -n <namespace> process -f mjml.deploy.yml | oc apply -f -
 oc -n <namespace> process -f web-frontend.deploy.yml | oc apply -f -
 ```
@@ -64,19 +70,20 @@ oc get all,pvc -l app=baserow -l component=web-frontend
 
 The entire stack and all associated objects can be deleted. This is useful for testing and starting over from scratch.
 
-Stack deletion.
+Entire stack deletion.
 
 ```
-oc delete all,pvc -l app=baserow
+oc -n <namespace> delete all,pvc -l app=baserow
+oc -n <namespace> delete secret/baserow-database
 ```
 
 Component deletion.
 
 ```
-oc delete all,pvc -l app=baserow -l component=backend
-oc delete all,pvc -l app=baserow -l component=database
-oc delete all,pvc -l app=baserow -l component=mjml
-oc delete all,pvc -l app=baserow -l component=web-frontend
+oc -n <namespace> delete all,pvc -l app=baserow -l component=backend
+oc -n <namespace> delete all,pvc -l app=baserow -l component=database
+oc -n <namespace> delete all,pvc -l app=baserow -l component=mjml
+oc -n <namespace> delete all,pvc -l app=baserow -l component=web-frontend
 ```
 
 ### Reference

--- a/README.md
+++ b/README.md
@@ -1,4 +1,22 @@
-# baserow
+# BaseRow on OpenShift
+
+<!-- TOC -->
+
+- [BaseRow on OpenShift](#baserow-on-openshift)
+  - [Description](#description)
+  - [Installation](#installation)
+    - [Network Security Policies](#network-security-policies)
+    - [Recommended](#recommended)
+    - [Simultaneous](#simultaneous)
+    - [Public URL](#public-url)
+  - [Labels](#labels)
+    - [Object grouping](#object-grouping)
+  - [Cleanup](#cleanup)
+    - [Removal](#removal)
+  - [Reference](#reference)
+  - [Issues](#issues)
+
+<!-- /TOC -->
 
 ### Description
 
@@ -10,7 +28,7 @@ These are templates used to deploy baserow to the BC Government's OpenShift clus
 
 #### Network Security Policies
 
-Ensure the NSP has been created in each of `-dev`, `-test`, `-prod`,. For example:
+Ensure the NSP has been created in each of `-dev`, `-test`, `-prod`. For example:
 
 ```bash
 oc -n <namespace> process -f https://raw.githubusercontent.com/BCDevOps/platform-services/master/security/aporeto/docs/sample/quickstart-nsp.yaml NAMESPACE=245e18-dev | oc -n <namespace> create -f -
@@ -21,17 +39,17 @@ oc -n <namespace> process -f https://raw.githubusercontent.com/BCDevOps/platform
 Process and apply build templates.
 
 ```bash
-oc -n <namespace> process -f backend.build.yml | oc apply -f -
-oc -n <namespace> process -f mjml.build.yml | oc apply -f -
+oc -n <namespace> process -f backend.build.yml      | oc apply -f -
+oc -n <namespace> process -f mjml.build.yml         | oc apply -f -
 oc -n <namespace> process -f web-frontend.build.yml | oc apply -f -
 ```
 
 Process and apply deploy templates.
 
 ```bash
-oc -n <namespace> process -f database.deploy.yml | oc apply -f -
-oc -n <namespace> process -f backend.deploy.yml | oc apply -f -
-oc -n <namespace> process -f mjml.deploy.yml | oc apply -f -
+oc -n <namespace> process -f database.deploy.yml     | oc apply -f -
+oc -n <namespace> process -f backend.deploy.yml      | oc apply -f -
+oc -n <namespace> process -f mjml.deploy.yml         | oc apply -f -
 oc -n <namespace> process -f web-frontend.deploy.yml | oc apply -f -
 ```
 
@@ -43,9 +61,15 @@ It is possible, but not advisable, to process and apply all templates at once. O
 for i in $(ls *.yml); do (oc process -f $i | oc apply -f -); done
 ```
 
+#### Public URL
+
+The URL will of of the form:
+
+`https://baserow-web-frontend-<namespace>.apps.silver.devops.gov.bc.ca/dashboard`
+
 ### Labels
 
-The default labels app=baserow and component=<component> are assigned to all objects. This is useful for troubleshooting.
+The default labels `app=baserow` and `component=<component>` are assigned to all objects. This is useful for troubleshooting.
 
 #### Object grouping
 
@@ -55,16 +79,16 @@ View a summary of the entire stack and associated objects.
 oc get all,pvc -l app=baserow
 ```
 
-View each group of component objects separately. These are backend, database, mjml and web-frontend.
+View each group of component objects separately. These are `backend`, `database`, `mjml` and `web-frontend`.
 
-```
+```bash
 oc get all,pvc -l app=baserow -l component=backend
 oc get all,pvc -l app=baserow -l component=database
 oc get all,pvc -l app=baserow -l component=mjml
 oc get all,pvc -l app=baserow -l component=web-frontend
 ```
 
-### Removal
+### Cleanup
 
 #### Removal
 
@@ -72,14 +96,14 @@ The entire stack and all associated objects can be deleted. This is useful for t
 
 Entire stack deletion.
 
-```
+```bash
 oc -n <namespace> delete all,pvc -l app=baserow
 oc -n <namespace> delete secret/baserow-database
 ```
 
 Component deletion.
 
-```
+```bash
 oc -n <namespace> delete all,pvc -l app=baserow -l component=backend
 oc -n <namespace> delete all,pvc -l app=baserow -l component=database
 oc -n <namespace> delete all,pvc -l app=baserow -l component=mjml
@@ -102,16 +126,19 @@ oc -n <namespace> delete all,pvc -l app=baserow -l component=web-frontend
 
 ### Issues
 
-To do:
+To Do:
 
-1. Close the backend private port. Traffic through the private port is currently failing.
-2. Deployment across namespaces has not been verified.
+- Close the backend private port. Traffic through the private port is currently failing.
+- Deployment across namespaces has not been verified.
+  - Store image in `-tools` namespace, and pull from there
+- Backend ALLOWED_HOSTS are not being updated. A workaround uses the ALLOWED_HOSTS_FIX variable in `backend.build.yml`.
+- `mjml` has not been tested.
+- OpenShift Overview Panel does not usually link to the web-frontend.
+- `backend` liveness probe is causing restarts. It has temporarily been commented out.
+- `backend` and `web-frontend` are using `:latest` tags. Please specify a stable release number for production.
+- Tighten up the generic Network Security Policy, to the bare minimum to allow the pods to communicate with each other.
 
-- Store image in `-tools` namespace, and pull from there
+Done:
 
-3. Backend ALLOWED_HOSTS are not being updated. A workaround uses the ALLOWED_HOSTS_FIX variable in backend.build.yml.
-4. Use more secure passwords. The database is currently using `baserow` for the username, password and db name.
-5. mjml has not been tested.
-6. OpenShift Overview Panel does not usually link to the web-frontend.
-7. Backend liveness probe is causing restarts. It has temporarily been commented out.
-8. Backend and web-frontend are using :latest tags. Please specify a stable release number for production.
+- Use more secure passwords. The database was using a hardcoded password, but the deploy now generates a new password on each deployment.
+- Generate a new SECRET_KEY has on each deploy

--- a/README.md
+++ b/README.md
@@ -6,29 +6,32 @@ Baserow is an open source online database tool and Airtable alternative. Create 
 
 These are templates used to deploy baserow to the BC Government's OpenShift cluster.
 
-
 ### Installation
 
 #### Recommended
 
+oc -n 245e18-dev process -f https://raw.githubusercontent.com/BCDevOps/platform-services/master/security/aporeto/docs/sample/quickstart-nsp.yaml NAMESPACE=245e18-dev | oc -n 245e18-dev create -f -
+
 Process and apply build templates.
-```
-oc process -f backend.build.yml | oc apply -f -
-oc process -f mjml.build.yml | oc apply -f -
-oc process -f web-frontend.build.yml | oc apply -f -
+
+```bash
+oc -n <namespace> process -f backend.build.yml | oc apply -f -
+oc -n <namespace> process -f mjml.build.yml | oc apply -f -
+oc -n <namespace> process -f web-frontend.build.yml | oc apply -f -
 ```
 
 Process and apply deploy templates.
-```
-oc process -f backend.deploy.yml | oc apply -f -
-oc process -f database.deploy.yml | oc apply -f -
-oc process -f mjml.deploy.yml | oc apply -f -
-oc process -f web-frontend.deploy.yml | oc apply -f -
+
+```bash
+oc -n <namespace> process -f backend.deploy.yml | oc apply -f -
+oc -n <namespace> process -f database.deploy.yml | oc apply -f -
+oc -n <namespace> process -f mjml.deploy.yml | oc apply -f -
+oc -n <namespace> process -f web-frontend.deploy.yml | oc apply -f -
 ```
 
 #### Simultaneous
 
-It is possible, but not advisable, to process and apply all templates at once.  OpenShift and the templates are generally able to handle the chaos.
+It is possible, but not advisable, to process and apply all templates at once. OpenShift and the templates are generally able to handle the chaos.
 
 ```
 for i in $(ls *.yml); do (oc process -f $i | oc apply -f -); done
@@ -36,7 +39,7 @@ for i in $(ls *.yml); do (oc process -f $i | oc apply -f -); done
 
 ### Labels
 
-The default labels app=baserow and component=<component> are assigned to all objects.  This is useful for troubleshooting.
+The default labels app=baserow and component=<component> are assigned to all objects. This is useful for troubleshooting.
 
 #### Object grouping
 
@@ -46,7 +49,7 @@ View a summary of the entire stack and associated objects.
 oc get all,pvc -l app=baserow
 ```
 
-View each group of component objects separately.  These are backend, database, mjml and web-frontend.
+View each group of component objects separately. These are backend, database, mjml and web-frontend.
 
 ```
 oc get all,pvc -l app=baserow -l component=backend
@@ -59,7 +62,7 @@ oc get all,pvc -l app=baserow -l component=web-frontend
 
 #### Removal
 
-The entire stack and all associated objects can be deleted.  This is useful for testing and starting over from scratch.
+The entire stack and all associated objects can be deleted. This is useful for testing and starting over from scratch.
 
 Stack deletion.
 
@@ -90,17 +93,18 @@ oc delete all,pvc -l app=baserow -l component=web-frontend
 
 [Backend API redoc](https://api.baserow.io/api/redoc/)
 
-
 ### Issues
 
 To do:
 
-1. Close the backend private port.  Traffic through the private port is currently failing.
+1. Close the backend private port. Traffic through the private port is currently failing.
 2. Deployment across namespaces has not been verified.
-3. Backend ALLOWED_HOSTS are not being updated.  A workaround uses the ALLOWED_HOSTS_FIX variable in backend.build.yml.
-4. Use more secure passwords.  The database is currently using `baserow` for the username, password and db name.
+
+- Store image in `-tools` namespace, and pull from there
+
+3. Backend ALLOWED_HOSTS are not being updated. A workaround uses the ALLOWED_HOSTS_FIX variable in backend.build.yml.
+4. Use more secure passwords. The database is currently using `baserow` for the username, password and db name.
 5. mjml has not been tested.
 6. OpenShift Overview Panel does not usually link to the web-frontend.
-7. Backend liveness probe is causing restarts.  It has temporarily been commented out.
-8. Backend and web-frontend are using :latest tags.  Please specify a stable release number for production.
-9. There's always something else!
+7. Backend liveness probe is causing restarts. It has temporarily been commented out.
+8. Backend and web-frontend are using :latest tags. Please specify a stable release number for production.

--- a/backend.build.yml
+++ b/backend.build.yml
@@ -11,6 +11,8 @@ parameters:
     value: baserow
   - name: COMPONENT
     value: backend
+  - name: COMPONENT_FRONTEND
+    value: web-frontend
   - name: BUILD_TAG
     value: latest
   - name: IMG_SRC_TAG
@@ -66,7 +68,7 @@ objects:
           RUN pip3 install -r ./requirements/base.txt
 
           # Bug - URLs not automatically being added to ALLOWED_HOSTS
-          ENV ALLOWED_HOSTS_FIX=${APP}-${COMPONENT}-${DEPLOY_NAMESPACE}.${DOMAIN}
+          ENV ALLOWED_HOSTS_FIX=${APP}-${COMPONENT_FRONTEND}-${DEPLOY_NAMESPACE}.${DOMAIN}
           RUN sed -i "/^ALLOWED_HOSTS =.*/a ALLOWED_HOSTS.append(\'${ALLOWED_HOSTS_FIX}\')" \
                 src/baserow/config/settings/base.py
 

--- a/backend.build.yml
+++ b/backend.build.yml
@@ -20,11 +20,11 @@ parameters:
   - name: IMG_SRC_NAMESPACE
     value: openshift
   - name: IMG_SRC_REPO
-    value: docker-registry.default.svc:5000
+    value: image-registry.openshift-image-registry.svc:5000
   - name: DEPLOY_NAMESPACE
-    value: csnr-devops-lab-deploy
+    value: 245e18-dev
   - name: DOMAIN
-    value: pathfinder.gov.bc.ca
+    value: apps.silver.devops.gov.bc.ca
   - name: CLONE_GIT_RELEASE
     value: "0.5.0"
   - name: CLONE_GIT_URL

--- a/backend.build.yml
+++ b/backend.build.yml
@@ -29,10 +29,6 @@ parameters:
     value: "0.5.0"
   - name: CLONE_GIT_URL
     value: https://gitlab.com/bramw/baserow.git
-  # - name: CLONE_GIT_RELEASE
-  #   value: "feature/debug"    
-  # - name: CLONE_GIT_URL
-  #   value: https://gitlab.com/garywong/baserow.git
 objects:
   - apiVersion: v1
     kind: ImageStream

--- a/backend.build.yml
+++ b/backend.build.yml
@@ -11,8 +11,6 @@ parameters:
     value: baserow
   - name: COMPONENT
     value: backend
-  - name: COMPONENT_FRONTEND
-    value: web-frontend
   - name: BUILD_TAG
     value: latest
   - name: IMG_SRC_TAG
@@ -27,14 +25,14 @@ parameters:
     value: 245e18-dev
   - name: DOMAIN
     value: apps.silver.devops.gov.bc.ca
-  - name: CLONE_GIT_RELEASE_UPSTREAM
-    value: "0.5.0"
-  - name: CLONE_GIT_URL_UPSTREAM
-    value: https://gitlab.com/bramw/baserow.git
   - name: CLONE_GIT_RELEASE
-    value: "feature/debug"    
+    value: "0.5.0"
   - name: CLONE_GIT_URL
-    value: https://gitlab.com/garywong/baserow.git
+    value: https://gitlab.com/bramw/baserow.git
+  # - name: CLONE_GIT_RELEASE
+  #   value: "feature/debug"    
+  # - name: CLONE_GIT_URL
+  #   value: https://gitlab.com/garywong/baserow.git
 objects:
   - apiVersion: v1
     kind: ImageStream
@@ -72,8 +70,7 @@ objects:
           RUN pip3 install -r ./requirements/base.txt
 
           # Bug - URLs not automatically being added to ALLOWED_HOSTS
-          # ENV ALLOWED_HOSTS_FIX=${APP}-${COMPONENT_FRONTEND}-${DEPLOY_NAMESPACE}.${DOMAIN}
-          ENV ALLOWED_HOSTS_FIX=baserow-web-frontend
+          ENV ALLOWED_HOSTS_FIX=${APP}-${COMPONENT}-${DEPLOY_NAMESPACE}.${DOMAIN}
           RUN sed -i "/^ALLOWED_HOSTS =.*/a ALLOWED_HOSTS.append(\'${ALLOWED_HOSTS_FIX}\')" \
                 src/baserow/config/settings/base.py
           CMD gunicorn --workers=3 -b 0.0.0.0:8000 baserow.config.wsgi

--- a/backend.build.yml
+++ b/backend.build.yml
@@ -31,6 +31,11 @@ parameters:
     value: "0.5.0"
   - name: CLONE_GIT_URL
     value: https://gitlab.com/bramw/baserow.git
+  # - name: CLONE_GIT_RELEASE
+  #   value: "feature/debug"    
+  # - name: CLONE_GIT_URL
+  #   value: https://gitlab.com/garywong/baserow.git
+
 objects:
   - apiVersion: v1
     kind: ImageStream

--- a/backend.build.yml
+++ b/backend.build.yml
@@ -27,15 +27,14 @@ parameters:
     value: 245e18-dev
   - name: DOMAIN
     value: apps.silver.devops.gov.bc.ca
-  - name: CLONE_GIT_RELEASE
+  - name: CLONE_GIT_RELEASE_UPSTREAM
     value: "0.5.0"
-  - name: CLONE_GIT_URL
+  - name: CLONE_GIT_URL_UPSTREAM
     value: https://gitlab.com/bramw/baserow.git
-  # - name: CLONE_GIT_RELEASE
-  #   value: "feature/debug"    
-  # - name: CLONE_GIT_URL
-  #   value: https://gitlab.com/garywong/baserow.git
-
+  - name: CLONE_GIT_RELEASE
+    value: "feature/debug"    
+  - name: CLONE_GIT_URL
+    value: https://gitlab.com/garywong/baserow.git
 objects:
   - apiVersion: v1
     kind: ImageStream
@@ -73,10 +72,10 @@ objects:
           RUN pip3 install -r ./requirements/base.txt
 
           # Bug - URLs not automatically being added to ALLOWED_HOSTS
-          ENV ALLOWED_HOSTS_FIX=${APP}-${COMPONENT_FRONTEND}-${DEPLOY_NAMESPACE}.${DOMAIN}
+          # ENV ALLOWED_HOSTS_FIX=${APP}-${COMPONENT_FRONTEND}-${DEPLOY_NAMESPACE}.${DOMAIN}
+          ENV ALLOWED_HOSTS_FIX=baserow-web-frontend
           RUN sed -i "/^ALLOWED_HOSTS =.*/a ALLOWED_HOSTS.append(\'${ALLOWED_HOSTS_FIX}\')" \
                 src/baserow/config/settings/base.py
-
           CMD gunicorn --workers=3 -b 0.0.0.0:8000 baserow.config.wsgi
 
         type: Dockerfile

--- a/backend.deploy.yml
+++ b/backend.deploy.yml
@@ -27,10 +27,10 @@ parameters:
     value: database
   - name: MJML_COMPONENT
     value: mjml
-  - name: SRC_GIT_URL_UPSTREAM
-    value: https://gitlab.com/bramw/baserow.git
   - name: SRC_GIT_URL
-    value: https://gitlab.com/garywong/baserow.git
+    value: https://gitlab.com/bramw/baserow.git
+  # - name: SRC_GIT_URL
+  #   value: https://gitlab.com/garywong/baserow.git
 objects:
   - apiVersion: v1
     kind: DeploymentConfig

--- a/backend.deploy.yml
+++ b/backend.deploy.yml
@@ -29,6 +29,8 @@ parameters:
     value: mjml
   - name: SRC_GIT_URL
     value: https://gitlab.com/bramw/baserow.git
+  # - name: SRC_GIT_URL
+  #   value: https://gitlab.com/garywong/baserow.git
 objects:
   - apiVersion: v1
     kind: DeploymentConfig

--- a/backend.deploy.yml
+++ b/backend.deploy.yml
@@ -16,13 +16,13 @@ parameters:
   - name: APP_PORT
     value: "8000"
   - name: APP_NAMESPACE
-    value: csnr-devops-lab-deploy
+    value: 245e18-dev
   - name: WEB_FRONTEND_NAMESPACE
-    value: csnr-devops-lab-deploy
+    value: 245e18-dev
   - name: WEB_FRONTEND_COMPONENT
     value: web-frontend
   - name: DOMAIN
-    value: pathfinder.gov.bc.ca
+    value: apps.silver.devops.gov.bc.ca
   - name: DATABASE_COMPONENT
     value: database
   - name: MJML_COMPONENT

--- a/backend.deploy.yml
+++ b/backend.deploy.yml
@@ -29,8 +29,12 @@ parameters:
     value: mjml
   - name: SRC_GIT_URL
     value: https://gitlab.com/bramw/baserow.git
-  # - name: SRC_GIT_URL
-  #   value: https://gitlab.com/garywong/baserow.git
+  - description: Secret Key for the Application token generator.
+    displayName: Secret Key
+    from: "[a-zA-Z0-9]{24}"
+    generate: expression
+    name: SECRET_KEY
+    required: true
 objects:
   - apiVersion: v1
     kind: DeploymentConfig
@@ -71,23 +75,15 @@ objects:
                 do echo waiting for database; sleep 2; done;"]
           containers:
             - env:
-                - name: POSTGRESQL_USER
-                  valueFrom:
-                    secretKeyRef:
-                      key: database-user
-                      name: ${APP}-${DATABASE_COMPONENT}
-                - name: POSTGRESQL_PASSWORD
+                - name: DATABASE_PASSWORD
                   valueFrom:
                     secretKeyRef:
                       key: database-password
                       name: ${APP}-${DATABASE_COMPONENT}
-                - name: POSTGRESQL_DATABASE
-                  valueFrom:
-                    secretKeyRef:
-                      key: database-name
-                      name: ${APP}-${DATABASE_COMPONENT}
                 - name: DATABASE_HOST
                   value: ${APP}-${DATABASE_COMPONENT}
+                - name: SECRET_KEY
+                  value: "${SECRET_KEY}"
                 - name: MJML_SERVER_HOST
                   value: ${APP}-${MJML_COMPONENT}
                 - name: PUBLIC_WEB_FRONTEND_URL

--- a/backend.deploy.yml
+++ b/backend.deploy.yml
@@ -27,10 +27,10 @@ parameters:
     value: database
   - name: MJML_COMPONENT
     value: mjml
-  - name: SRC_GIT_URL
+  - name: SRC_GIT_URL_UPSTREAM
     value: https://gitlab.com/bramw/baserow.git
-  # - name: SRC_GIT_URL
-  #   value: https://gitlab.com/garywong/baserow.git
+  - name: SRC_GIT_URL
+    value: https://gitlab.com/garywong/baserow.git
 objects:
   - apiVersion: v1
     kind: DeploymentConfig

--- a/database.deploy.yml
+++ b/database.deploy.yml
@@ -8,21 +8,26 @@ parameters:
     value: database
   - name: IMG_TAG
     value: "10"
+  - description: Password for the PostgreSQL connection user.
+    displayName: PostgreSQL Connection Password
+    from: "[a-zA-Z0-9]{16}"
+    generate: expression
+    name: POSTGRESQL_PASSWORD
+    required: true    
 labels:
   app: ${APP}
   component: ${COMPONENT}
 objects:
   - apiVersion: v1
-    data:
-      database-name: YmFzZXJvdw==
-      database-password: YmFzZXJvdw==
-      database-user: YmFzZXJvdw==
     kind: Secret
     metadata:
       labels:
         app: ${APP}
       name: ${APP}-${COMPONENT}
-    type: Opaque
+    stringData:
+      database-name: baserow
+      database-password: "${POSTGRESQL_PASSWORD}"
+      database-user: baserow
   - apiVersion: v1
     kind: PersistentVolumeClaim
     metadata:

--- a/database.deploy.yml
+++ b/database.deploy.yml
@@ -7,7 +7,7 @@ parameters:
   - name: COMPONENT
     value: database
   - name: IMG_TAG
-    value: latest
+    value: "10"
 labels:
   app: ${APP}
   component: ${COMPONENT}
@@ -81,7 +81,7 @@ objects:
                     secretKeyRef:
                       key: database-name
                       name: ${APP}-${COMPONENT}
-              image: docker-registry.default.svc:5000/openshift/postgresql@sha256:094097e33f6d3cd498194ad7dc7bdb32f3d62b6a56ad8ae425770cd4050ad611
+              image: image-registry.openshift-image-registry.svc:5000/openshift/postgresql:10
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 exec:

--- a/mjml.build.yml
+++ b/mjml.build.yml
@@ -7,9 +7,9 @@ parameters:
   - name: COMPONENT
     value: mjml
   - name: IMG_SRC_REPO
-    value: docker.io/liminspace/mjml-tcpserver
+    value: docker-remote.artifacts.developer.gov.bc.ca/liminspace/mjml-tcpserver
   - name: IMG_SRC_TAG
-    value: "10"
+    value: "0.10"
 labels:
   app: ${APP}
   component: ${COMPONENT}

--- a/mjml.deploy.yml
+++ b/mjml.deploy.yml
@@ -9,9 +9,9 @@ parameters:
   - name: SRC_TAG
     value: "10"
   - name: SRC_NAMESPACE
-    value: csnr-devops-lab-deploy
+    value: 245e18-dev
   - name: SRC_REGISTRY
-    value: docker-registry.default.svc:5000
+    value: image-registry.openshift-image-registry.svc:5000
 labels:
   app: ${APP}
   component: ${COMPONENT}

--- a/mjml.deploy.yml
+++ b/mjml.deploy.yml
@@ -7,7 +7,7 @@ parameters:
   - name: COMPONENT
     value: mjml
   - name: SRC_TAG
-    value: "10"
+    value: "0.10"
   - name: SRC_NAMESPACE
     value: 245e18-dev
   - name: SRC_REGISTRY
@@ -43,6 +43,8 @@ objects:
               ports:
                 - containerPort: 28101
               resources: {}
+          imagePullSecrets:
+          - name: docker-pull-passthru
           restartPolicy: Always
       test: false
       triggers:

--- a/web-frontend.build.yml
+++ b/web-frontend.build.yml
@@ -47,7 +47,7 @@ objects:
         component: ${COMPONENT}
       source:
         dockerfile: |
-          FROM docker-registry.default.svc:5000/openshift/nodejs:10
+          FROM image-registry.openshift-image-registry.svc:5000/openshift/nodejs:10
 
           USER root
           WORKDIR /web-frontend
@@ -60,7 +60,7 @@ objects:
               chown -R 1000870000:0 /.npm && \
               chmod -R 777 /web-frontend
 
-          RUN npm install
+          RUN npm install --unsafe-perm=true --allow-root
           RUN npm run build
 
           CMD npm run start

--- a/web-frontend.build.yml
+++ b/web-frontend.build.yml
@@ -13,14 +13,14 @@ parameters:
     value: latest
   - name: IMG_SRC_TAG
     value: latest
-  - name: SRC_GIT_URL_UPSTREAM
-    value: https://gitlab.com/bramw/baserow.git
-  - name: SRC_RELEASE_UPSTREAM
-    value: 0.5.0
   - name: SRC_GIT_URL
-    value: https://gitlab.com/garywong/baserow.git
+    value: https://gitlab.com/bramw/baserow.git
   - name: SRC_RELEASE
-    value: "feature/debug"  
+    value: 0.5.0
+  # - name: SRC_GIT_URL
+  #   value: https://gitlab.com/garywong/baserow.git
+  # - name: SRC_RELEASE
+  #   value: "feature/debug"  
 objects:
   - apiVersion: v1
     kind: ImageStream

--- a/web-frontend.build.yml
+++ b/web-frontend.build.yml
@@ -17,6 +17,10 @@ parameters:
     value: https://gitlab.com/bramw/baserow.git
   - name: SRC_RELEASE
     value: 0.5.0
+  # - name: SRC_GIT_URL
+  #   value: https://gitlab.com/garywong/baserow.git
+  # - name: SRC_RELEASE
+  #   value: "feature/debug"  
 objects:
   - apiVersion: v1
     kind: ImageStream

--- a/web-frontend.build.yml
+++ b/web-frontend.build.yml
@@ -13,14 +13,14 @@ parameters:
     value: latest
   - name: IMG_SRC_TAG
     value: latest
-  - name: SRC_GIT_URL
+  - name: SRC_GIT_URL_UPSTREAM
     value: https://gitlab.com/bramw/baserow.git
-  - name: SRC_RELEASE
+  - name: SRC_RELEASE_UPSTREAM
     value: 0.5.0
-  # - name: SRC_GIT_URL
-  #   value: https://gitlab.com/garywong/baserow.git
-  # - name: SRC_RELEASE
-  #   value: "feature/debug"  
+  - name: SRC_GIT_URL
+    value: https://gitlab.com/garywong/baserow.git
+  - name: SRC_RELEASE
+    value: "feature/debug"  
 objects:
   - apiVersion: v1
     kind: ImageStream

--- a/web-frontend.deploy.yml
+++ b/web-frontend.deploy.yml
@@ -18,9 +18,9 @@ parameters:
   - name: BACKEND_PORT
     value: "8000"
   - name: NAMESPACE
-    value: csnr-devops-lab-deploy
+    value: 245e18-dev
   - name: DOMAIN
-    value: pathfinder.gov.bc.ca
+    value: apps.silver.devops.gov.bc.ca
 objects:
   - apiVersion: v1
     kind: DeploymentConfig


### PR DESCRIPTION
* update cluster and image repo references
* work around new `docker.io` rate limiting by using `passthrough pull` via BC Gov Artifactory image repo
* supersede hardcoded Database password with OpenShift generated one
* add application SECRET_KEY hash, autogenerated from OpenShift
* renamed `backend` POSTGRESQL_ environment DB variables to match python code DATABASE_; note that I left the `database` variables as-is to match default PostgreSQL names

Note that this assumes that:
- Network Security Policy has been created
-  permissions to pull image from `-tools`
-  Artifactory credentials have been created in a secret, from the default `-tools` namespace's secret